### PR TITLE
Fix simple fields array

### DIFF
--- a/lib/ACFComposer/ResolveConfig.php
+++ b/lib/ACFComposer/ResolveConfig.php
@@ -39,8 +39,13 @@ class ResolveConfig {
 
   protected static function forEntity($config, $requiredAttributes, $parentKeys = []) {
     if (is_string($config)) {
-      // TODO catch unapplied filters and show warning, then get out of this function to prevent exceptions
-      $config = apply_filters($config, null);
+      $filterName = $config;
+      $config = apply_filters($filterName, null);
+
+      if (is_null($config)) {
+        trigger_error("ACFComposer: Filter {$filterName} does not exist!", E_USER_WARNING);
+        return [];
+      }
     }
     if (!self::isAssoc($config)) {
       return array_map(function ($singleConfig) use ($requiredAttributes, $parentKeys) {

--- a/tests/test-resolveConfigForField.php
+++ b/tests/test-resolveConfigForField.php
@@ -71,6 +71,24 @@ class ResolveConfigForFieldTest extends TestCase {
     $this->assertEquals($someField, $output);
   }
 
+  function testForFieldTriggerErrorWithoutFilter() {
+    $config = 'ACFComposer/Fields/someField';
+    Filters::expectApplied($config)
+    ->once()
+    ->andReturn(null);
+    $this->expectException('PHPUnit_Framework_Error_Warning');
+    $output = ResolveConfig::forField($config);
+  }
+
+  function testForFieldReturnEmptyArrayWithoutFilter() {
+    $config = 'ACFComposer/Fields/someField';
+    Filters::expectApplied($config)
+    ->once()
+    ->andReturn(null);
+    $output = @ResolveConfig::forField($config);
+    $this->assertEquals($output, []);
+  }
+
   function testForFieldWithValidSubField() {
     $subFieldConfig = [
       'name' => 'subField',

--- a/tests/test-resolveConfigForFieldGroup.php
+++ b/tests/test-resolveConfigForFieldGroup.php
@@ -8,6 +8,7 @@ use Brain\Monkey\WP\Filters;
 
 class ResolveConfigForFieldGroupTest extends TestCase {
   function testForFieldGroupWithValidConfig() {
+    $filterName = 'ACFComposer/Fields/someField';
     $fieldConfig = [
       'name' => 'someField',
       'label' => 'Some Field',
@@ -21,15 +22,23 @@ class ResolveConfigForFieldGroupTest extends TestCase {
     $config = [
       'name' => 'someGroup',
       'title' => 'Some Group',
-      'fields' => [$fieldConfig],
+      'fields' => [
+        $filterName,
+        $fieldConfig
+      ],
       'location' => [
         [$locationConfig]
       ]
     ];
+
+    Filters::expectApplied($filterName)
+    ->once()
+    ->andReturn($fieldConfig);
+
     $output = ResolveConfig::forFieldGroup($config);
     $fieldConfig['key'] = 'field_someGroup_someField';
     $config['key'] = 'group_someGroup';
-    $config['fields'] = [$fieldConfig];
+    $config['fields'] = [$fieldConfig, $fieldConfig];
     $this->assertEquals($config, $output);
   }
 

--- a/tests/test-resolveConfigForFieldGroup.php
+++ b/tests/test-resolveConfigForFieldGroup.php
@@ -14,6 +14,18 @@ class ResolveConfigForFieldGroupTest extends TestCase {
       'label' => 'Some Field',
       'type' => 'someType'
     ];
+    $fieldConfigMulti = [
+      [
+        'name' => 'someField1',
+        'label' => 'Some Field1',
+        'type' => 'someType'
+      ],
+      [
+        'name' => 'someField2',
+        'label' => 'Some Field2',
+        'type' => 'someType'
+      ]
+    ];
     $locationConfig = [
       'param' => 'someParam',
       'operator' => 'someOperator',
@@ -24,7 +36,8 @@ class ResolveConfigForFieldGroupTest extends TestCase {
       'title' => 'Some Group',
       'fields' => [
         $filterName,
-        $fieldConfig
+        $fieldConfig,
+        $fieldConfigMulti
       ],
       'location' => [
         [$locationConfig]
@@ -37,8 +50,10 @@ class ResolveConfigForFieldGroupTest extends TestCase {
 
     $output = ResolveConfig::forFieldGroup($config);
     $fieldConfig['key'] = 'field_someGroup_someField';
+    $fieldConfigMulti[0]['key'] = 'field_someGroup_someField1';
+    $fieldConfigMulti[1]['key'] = 'field_someGroup_someField2';
     $config['key'] = 'group_someGroup';
-    $config['fields'] = [$fieldConfig, $fieldConfig];
+    $config['fields'] = [$fieldConfig, $fieldConfig, $fieldConfigMulti[0], $fieldConfigMulti[1]];
     $this->assertEquals($config, $output);
   }
 


### PR DESCRIPTION
Added ability to use Filters on the first level of a field group as well.

Not quite sure how to adjust the tests for this...

Also added a simple check if the filter is added anywhere and prevented the plugin from breaking with a php exception in this case.

EDIT: I added a test to increase coverage and pass the checks, but it seems [Scrutinizr has crashed](https://scrutinizer-ci.com/g/bleech/acf-field-group-composer/inspections/5da997e5-4c40-4d7f-9050-f85de9593fd9)? @domtra any ideas why?