### PR TITLE
Update ResolveConfig.php

### DIFF
--- a/lib/ACFComposer/ResolveConfig.php
+++ b/lib/ACFComposer/ResolveConfig.php
@@ -36,7 +36,7 @@ class ResolveConfig
      */
     public static function forLocation($config)
     {
-        return self::validateConfig($config, ['param', 'operator', 'value']);
+		return self::forEntity($config, ['param', 'operator', 'value']);
     }
 
     /**


### PR DESCRIPTION
I run following sample code and get an error. I manage to hot fix it.
`
add_filter('MyProject/ACF/fields/field1', function ($field) {
  return [
    'label' => 'Subtitle',
    'name' => 'subtitle',
    'type' => 'text'
  ];
});

add_filter('MyProject/ACF/locations/postTypePost', function ($location) {
  return [
    'param' => 'post_type',
    'operator' => '==',
    'value' => 'post'
  ];
});

$config = [
  'name' => 'group1',
  'title' => 'My Group',
  'fields' => [
    'MyProject/ACF/fields/field1'
  ],
  'location' => [
    [
      'MyProject/ACF/locations/postTypePost'
    ]
  ]
];

ACFComposer\ACFComposer::registerFieldGroup($config);
`

![image](https://user-images.githubusercontent.com/34735335/162183393-c46ac423-73d6-4408-8c23-43a3fe4a4249.png)
